### PR TITLE
Do not raise critical when raid is performing check.

### DIFF
--- a/snmp/check_arc_raid.c
+++ b/snmp/check_arc_raid.c
@@ -97,7 +97,7 @@ int main (int argc, char **argv) {
         if (rc == 0)
             break;
 
-        if (strcmp(raid_state, "Normal") == 0) {
+        if ( (strcmp(raid_state, "Normal") == 0) || (strcmp(raid_state, "Checking") == 0) ){
             continue;
         }
 


### PR DESCRIPTION
Hi. This is a small patch to avoid unnecessary alerts from nagios when raid is performing a check, as it should be considered as "normal" status.

For instance : CRITICAL - ARC: Raid Set # 000   is Checking

Regards.
